### PR TITLE
galaxy-humble: Persist config.ini

### DIFF
--- a/galaxy-humble.json
+++ b/galaxy-humble.json
@@ -69,7 +69,7 @@
         "        Write-Host \"Oops! Something's not right. The $app integration was installed, but the symlink was not possible.\" -f Red",
         "    }",
         "}",
-        "Write-Host \"This plugin has a config file located here: $persist_dir\\integration\\config.ini\" -f Yellow"
+        "Write-Host \"This plugin has a config file located here: $persist_dir\\integration\\config.ini\" -f Magenta"
     ],
     "checkver": {
         "github": "https://github.com/UncleGoogle/galaxy-integration-humblebundle"

--- a/galaxy-humble.json
+++ b/galaxy-humble.json
@@ -68,7 +68,8 @@
         "    } else {",
         "        Write-Host \"Oops! Something's not right. The $app integration was installed, but the symlink was not possible.\" -f Red",
         "    }",
-        "}"
+        "}",
+        "Write-Host \"This plugin has a config file located here: $persist_dir\\integration\\config.ini\" -f Yellow"
     ],
     "checkver": {
         "github": "https://github.com/UncleGoogle/galaxy-integration-humblebundle"

--- a/galaxy-humble.json
+++ b/galaxy-humble.json
@@ -6,6 +6,7 @@
     "hash": "53bca1d4273b93f4f2d234856e56568185d9cf5748b1650dbe9d7b20134a303e",
     "extract_dir": "humblebundle_0.4.1",
     "extract_to": "integration",
+    "persist": ["integration\\config.ini"],
     "uninstaller": {
         "script": [
             "(Get-Item \"$env:LOCALAPPDATA\\GOG.com\\Galaxy\\plugins\\installed\\humble\").Delete()"


### PR DESCRIPTION
Humble integration has a config file. This change persists it, so it survives updates, and also prints its path during install.